### PR TITLE
provide working ga-compatible example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ sha2 = "0.9"
 
 [dev-dependencies]
 version-sync = "0.9"
+koibumi-base32 = "0.0"

--- a/examples/ga.rs
+++ b/examples/ga.rs
@@ -1,0 +1,56 @@
+//! A Google Authenticator compatible TOTP implementation.
+//! Technical reference:
+//! https://en.wikipedia.org/wiki/Google_Authenticator#Technical_description
+//!
+//! In order to keep this example short it has no error handling, and
+//! therefore it can panic, for example if you enter an invalid base32
+//! character.
+//!
+//! You can run this example as follows:
+//! ```sh
+//!   cargo run --example ga
+//! ```
+
+use koibumi_base32 as base32;
+use std::io::{self, Write};
+use std::time::SystemTime;
+use totp_lite::{totp_custom, Sha1, DEFAULT_STEP};
+
+fn main() {
+    println!("Press ctrl-c to cancel.");
+    loop {
+        let mut input = String::new();
+
+        // Request the TOTP secret.
+        print!("Enter your TOTP secret: ");
+        io::stdout().flush().unwrap();
+        io::stdin().read_line(&mut input).unwrap();
+
+        let length = input.trim().len();
+        if length != 16 && length != 26 && length != 32 {
+            println!("Invalid TOTP secret, must be 16, 26 or 32 characters.");
+            continue;
+        }
+
+        // The number of seconds since the Unix Epoch, used to calcuate a TOTP secret.
+        let seconds: u64 = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Calculate a 6 digit TOTP two-factor authentication code.
+        println!(
+            "Your TOTP code: {}",
+            totp_custom::<Sha1>(
+                // Calculate a new code every 30 seconds.
+                DEFAULT_STEP,
+                // Calculate a 6 digit code.
+                6,
+                // Convert the secret into bytes using base32:decode().
+                &base32::decode(input.trim().to_lowercase().to_string()).unwrap(),
+                // Seconds since the Unix Epoch.
+                seconds,
+            )
+        );
+    }
+}

--- a/examples/ga.rs
+++ b/examples/ga.rs
@@ -46,7 +46,7 @@ fn main() {
                 DEFAULT_STEP,
                 // Calculate a 6 digit code.
                 6,
-                // Convert the secret into bytes using base32:decode().
+                // Convert the secret into bytes using base32::decode().
                 &base32::decode(input.trim().to_lowercase().to_string()).unwrap(),
                 // Seconds since the Unix Epoch.
                 seconds,


### PR DESCRIPTION
I needed a [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) compatible implementation. The primary difficulty was realizing I needed to use base32::decode() to convert the secret to bytes. This example will provide the same code as other GA-compatible password managers. I'm providing this example so it's easier for the next person trying to do the same.