### PR TITLE
Use sha1 instead of sha-1, which is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # totp-lite Changelog
 
+## 2.0.1 (2023-10-30)
+
+#### Changed
+
+- Switch to `sha1` to `sha-1`, which was deprecated. 
+
 ## 2.0.0 (2022-05-19)
 
 #### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totp-lite"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Colin Woodbury <colin@fosskers.ca>"]
 edition = "2018"
 description = "A simple, correct TOTP library."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ github = { repository = "fosskers/totp-lite", branch = "master", workflow = "Rus
 [dependencies]
 digest = "0.10"
 hmac = "0.12"
-sha-1 = "0.10"
+sha1 = "0.10"
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! [RFC6238]: https://tools.ietf.org/html/rfc6238
 
-#![doc(html_root_url = "https://docs.rs/totp-lite/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/totp-lite/2.0.1")]
 
 use digest::{
     block_buffer::Eager,


### PR DESCRIPTION
Hi,

Build fails with sha-1 for me.
If You could tag a new release that would be awesome.

Thanks,